### PR TITLE
Handle long description in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,8 @@
 formats = zip
 
 [metadata]
+long_description = file: pypi.md
+long_description_content_type = text/markdown
 license_files = 
     LICENSE.txt
     src/NOTICE.txt

--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,6 @@ from Cython.Build import cythonize
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-# Get the long description from the pypi.md file
-with open(os.path.join(here, 'pypi.md'), encoding='utf-8') as f:
-    long_description = f.read()
-
 define_macros = [('UNICODE', 1), ('_UNICODE', 1)]
 linetrace = False
 if int(os.environ.get('CYTHON_LINETRACE', '0')):
@@ -37,8 +33,6 @@ setup(
     name="dwriteshapepy", 
     version= '1.0.7',
     description="Python extension for Windows DirectWrite shaping, modeled after uharfbuzz ",
-    long_description=long_description,
-    long_description_content_type='text/markdown',
     author="Paul Linnerud",
     author_email="paulli@microsoft.com",
     url="https://github.com/microsoft/DWriteShapePy",


### PR DESCRIPTION
Building from source with pip fails because pypi.md is not included in the sdist archive. Hopefully this fixes it.