### PR TITLE
Work/paulli/pep625

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,12 +58,12 @@ jobs:
           name: wheels-artifact
           
       - name: Build Source Distribution 
-        run: python setup.py sdist
+        # Updated to ensure the source distribution is created with the .tar.gz extension
+        run: python setup.py sdist --formats=gztar
           
       - name: Upload Source Distribution
         uses: actions/upload-artifact@v4
         with:
-          path: ./dist/*.zip
+          # Updated the path to match the new .tar.gz file extension
+          path: ./dist/*.tar.gz
           name: source-dist-artifact
-
-      

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -53,12 +53,14 @@ jobs:
           name: wheels-artifact
           
       - name: Build Source Distribution 
-        run: python setup.py sdist
+        # Updated to ensure the source distribution is created with the .tar.gz extension
+        run: python setup.py sdist --formats=gztar
           
       - name: Upload Source Distribution
         uses: actions/upload-artifact@v4
         with:
-          path: ./dist/*.zip
+          # Updated the path to match the new .tar.gz file extension
+          path: ./dist/*.tar.gz
           name: source-dist-artifact
 
   upload_pypi:
@@ -83,4 +85,3 @@ jobs:
 
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-      


### PR DESCRIPTION
Earlier push to PyPI generated the below email. This PR should fix the issue. 

This email is notifying you of an upcoming deprecation that we have determined may affect you as a result of your recent upload to 'dwriteshapepy'. 
In the future, PyPI will require all newly uploaded source distribution filenames to comply with [PEP 625]. Any source distributions already uploaded will remain in place as-is and do not need to be updated. 
Specifically, your recent upload of 'dwriteshapepy-1.0.10.zip' is incompatible with PEP 625 because it uses the .zip file extension. 
In most cases, this can be resolved by upgrading the version of your build tooling to a later version that supports PEP 625 and produces compliant filenames.